### PR TITLE
Return JSON success flag and message from login

### DIFF
--- a/controllers/AuthController.php
+++ b/controllers/AuthController.php
@@ -36,11 +36,17 @@ class AuthController extends Controller
     public function actionLogin()
     {
         $model = new LoginForm();
-        $model->load(Yii::$app->request->bodyParams, '');
+        $body = Yii::$app->request->bodyParams;
+        if (isset($body['login']) && !isset($body['username'])) {
+            $body['username'] = $body['login'];
+        }
+        $model->load($body, '');
         if ($model->login()) {
             return ['success' => true, 'user' => Yii::$app->user->identity];
         }
-        return ['success' => false, 'errors' => $model->errors];
+        $errors = $model->getFirstErrors();
+        $message = reset($errors) ?: 'Invalid credentials';
+        return ['success' => false, 'message' => $message];
     }
 
     public function actionLogout()


### PR DESCRIPTION
## Summary
- handle `login` parameter in API login endpoint and map it to `username`
- return JSON `success` flag and include `message` on authentication failure

## Testing
- `vendor/bin/codecept run` *(fails: vendor/bin/codecept not found)*
- `composer install` *(fails: 403 while downloading packages from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_6892173f3ad08332bb8b66c299b9a562