### PR TITLE
Ensure API responses use UTF-8

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -80,11 +80,18 @@ $config = [
         'response' => [
             'format' => yii\web\Response::FORMAT_JSON,
             'charset' => 'UTF-8',
+            'formatters' => [
+                yii\web\Response::FORMAT_JSON => [
+                    'class' => yii\web\JsonResponseFormatter::class,
+                    'encodeOptions' => JSON_UNESCAPED_UNICODE,
+                ],
+            ],
             'on beforeSend' => function ($event) {
                 $response = $event->sender;
                 $response->headers->set('Access-Control-Allow-Origin', '*');
                 $response->headers->set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
                 $response->headers->set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+                $response->headers->set('Content-Type', 'application/json; charset=UTF-8');
             },
         ],
         'as cors' => [

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
-header('Content-Type: application/json');
+header('Content-Type: application/json; charset=UTF-8');
 header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Headers: Content-Type");
 


### PR DESCRIPTION
## Summary
- force UTF-8 for all JSON responses via response formatter and explicit Content-Type header
- set root API script to send UTF-8 encoded JSON

## Testing
- `vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689217e6a20c8332b470dbe3f1d402ba