### PR TITLE
Fix root index entrypoint

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,3 +1,5 @@
+<?php
 // Redirect all requests to the Yii application located in the `web` directory.
 // This allows using the framework's routing for endpoints like `/auth/login`.
 require __DIR__ . '/web/index.php';
+


### PR DESCRIPTION
## Summary
- add PHP opening tag to root index and delegate execution to `web/index.php`

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/codecept run` *(fails: vendor/bin/codecept: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689348ecb3a08332a8002105728bf4d8