### PR TITLE
Add console command to create users

### DIFF
--- a/commands/UserController.php
+++ b/commands/UserController.php
@@ -1,0 +1,46 @@
+<?php
+namespace app\commands;
+
+use yii\console\Controller;
+use yii\console\ExitCode;
+use yii\helpers\Console;
+use app\models\User;
+use Yii;
+
+/**
+ * Console controller for user management.
+ */
+class UserController extends Controller
+{
+    /**
+     * Creates a new user.
+     * Prompts for username, password and email; other fields are left empty or set to defaults.
+     *
+     * @return int Exit code
+     */
+    public function actionCreate()
+    {
+        $username = $this->prompt('Username:');
+        $password = $this->prompt('Password:');
+        $email = $this->prompt('Email:');
+
+        $user = new User();
+        $user->username = $username;
+        $user->email = $email;
+        $user->setPassword($password);
+        $user->generateAuthKey();
+        $user->organization_id = 1;
+        $user->created_at = time();
+        $user->updated_at = time();
+
+        if ($user->save()) {
+            $this->stdout("User '{$username}' created successfully.\n", Console::FG_GREEN);
+            return ExitCode::OK;
+        }
+
+        foreach ($user->getFirstErrors() as $attribute => $error) {
+            $this->stderr("$attribute: $error\n", Console::FG_RED);
+        }
+        return ExitCode::UNSPECIFIED_ERROR;
+    }
+}


### PR DESCRIPTION
## Summary
- add `user/create` console command to interactively create a new user

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/codecept run` *(fails: No such file or directory)*
- `php yii help user/create` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_6894a63494148332b3e3707aa11ddd67