### PR TITLE
feat: add user listing and result creation endpoints

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -56,6 +56,8 @@ return [
                 'POST auth/request-password-reset' => 'auth/request-password-reset',
                 'POST auth/reset-password' => 'auth/reset-password',
 
+                'GET users' => 'user/index',
+
                 'GET results' => 'result/index',
                 'POST results' => 'result/create',
                 'GET results/<id:\d+>' => 'result/view',

--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -1,10 +1,58 @@
 <?php
 namespace app\controllers;
 
-use yii\rest\ActiveController;
+use app\models\User;
+use Yii;
+use yii\filters\auth\HttpBearerAuth;
+use yii\filters\VerbFilter;
+use yii\rest\Controller;
 
-class UserController extends ActiveController
+class UserController extends Controller
 {
-    public $modelClass = 'app\models\User';
+    public function behaviors()
+    {
+        $b = parent::behaviors();
 
+        $b['authenticator'] = [
+            'class' => HttpBearerAuth::class,
+        ];
+
+        $b['verbs'] = [
+            'class' => VerbFilter::class,
+            'actions' => [
+                'index' => ['GET'],
+            ],
+        ];
+
+        return $b;
+    }
+
+    public function actionIndex()
+    {
+        $active = Yii::$app->request->get('active');
+        $query = User::find()->select(['id', 'first_name', 'last_name', 'username']);
+
+        if ($active === '1' && User::getTableSchema()->getColumn('status')) {
+            $query->andWhere(['status' => 10]);
+        }
+
+        $fetch = function () use ($query) {
+            $rows = $query->orderBy(['id' => SORT_ASC])->asArray()->all();
+            return array_map(function ($u) {
+                return [
+                    'id' => (int) $u['id'],
+                    'first_name' => $u['first_name'],
+                    'last_name' => $u['last_name'],
+                    'username' => $u['username'],
+                ];
+            }, $rows);
+        };
+
+        if (Yii::$app->has('cache')) {
+            $key = 'users_' . ($active === '1' ? 'active' : 'all');
+            return Yii::$app->cache->getOrSet($key, $fetch, 60);
+        }
+
+        return $fetch();
+    }
 }

--- a/migrations/m250812_130000_add_urgent_to_result_table.php
+++ b/migrations/m250812_130000_add_urgent_to_result_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use yii\db\Migration;
+
+class m250812_130000_add_urgent_to_result_table extends Migration
+{
+    public function safeUp()
+    {
+        if ($this->db->schema->getTableSchema('{{%result}}', true) === null) {
+            throw new \RuntimeException('Table "result" not found.');
+        }
+        if ($this->db->schema->getTableSchema('{{%result}}')->getColumn('urgent') === null) {
+            $this->addColumn('{{%result}}', 'urgent', $this->boolean()->notNull()->defaultValue(false)->after('expected_result'));
+        }
+    }
+
+    public function safeDown()
+    {
+        if ($this->db->schema->getTableSchema('{{%result}}', true) !== null && $this->db->schema->getTableSchema('{{%result}}')->getColumn('urgent') !== null) {
+            $this->dropColumn('{{%result}}', 'urgent');
+        }
+    }
+}

--- a/models/Result.php
+++ b/models/Result.php
@@ -12,6 +12,9 @@ use yii\db\ActiveRecord;
  * @property string $title
  * @property string|null $description
  * @property string|null $expected_result
+ * @property bool $urgent
+ * @property int|null $assigned_to
+ * @property int|null $setter_id
  * @property string|null $deadline        // DATE (Y-m-d)
  * @property int|null $created_by
  * @property int|null $created_at
@@ -33,11 +36,13 @@ class Result extends ActiveRecord
     public function rules()
     {
         return [
-            [['organization_id', 'title'], 'required'],
-            [['organization_id', 'created_by', 'created_at', 'updated_at', 'parent_id', 'completed_at'], 'integer'],
+            [['organization_id', 'title', 'expected_result', 'assigned_to'], 'required'],
+            [['organization_id', 'created_by', 'created_at', 'updated_at', 'parent_id', 'completed_at', 'assigned_to', 'setter_id'], 'integer'],
             [['description', 'expected_result'], 'string'],
             [['deadline'], 'date', 'format' => 'php:Y-m-d'],
             [['title'], 'string', 'max' => 255],
+            [['urgent'], 'boolean'],
+            [['urgent'], 'default', 'value' => false],
             [['parent_id'], 'validateParent'],
         ];
     }
@@ -52,6 +57,18 @@ class Result extends ActiveRecord
     public function fields()
     {
         $fields = parent::fields();
+
+        $fields['final_result'] = function () {
+            return $this->expected_result;
+        };
+        $fields['responsible_id'] = function () {
+            return $this->assigned_to;
+        };
+        $fields['urgent'] = function () {
+            return (bool) $this->urgent;
+        };
+
+        unset($fields['expected_result'], $fields['assigned_to']);
 
         $fields['children_count'] = function () {
             return (int) $this->getChildren()->count();
@@ -84,6 +101,16 @@ class Result extends ActiveRecord
         return $this->hasMany(Task::class, ['result_id' => 'id']);
     }
 
+    public function getAssignee(): ActiveQuery
+    {
+        return $this->hasOne(User::class, ['id' => 'assigned_to']);
+    }
+
+    public function getSetter(): ActiveQuery
+    {
+        return $this->hasOne(User::class, ['id' => 'setter_id']);
+    }
+
     public function beforeValidate()
     {
         if ($this->isNewRecord) {
@@ -95,6 +122,9 @@ class Result extends ActiveRecord
             }
             if (!$this->created_by && !Yii::$app->user->isGuest && isset(Yii::$app->user->id)) {
                 $this->created_by = (int) Yii::$app->user->id;
+            }
+            if (!$this->setter_id && !Yii::$app->user->isGuest && isset(Yii::$app->user->id)) {
+                $this->setter_id = (int) Yii::$app->user->id;
             }
         }
         return parent::beforeValidate();


### PR DESCRIPTION
## Summary
- provide authenticated user listing endpoint with optional caching and active filter
- expand result model with urgent flag, responsible mapping and rename final result
- handle result creation/update requests with API field mapping
- add migration for urgent column

## Testing
- `composer install` *(fails: curl error 56/28 - CONNECT tunnel failed, response 403)*
- `./vendor/bin/codecept run` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1ee209b483328312cd115a6fead0