### PR TITLE
Implement results API endpoints with validation

### DIFF
--- a/config/test_db.php
+++ b/config/test_db.php
@@ -1,6 +1,6 @@
 <?php
-$db = require __DIR__ . '/db.php';
-// test database! Important not to run tests on production or development databases
-$db['dsn'] = 'mysql:host=localhost;dbname=yii2basic_test';
-
-return $db;
+return [
+    'class' => 'yii\\db\\Connection',
+    'dsn' => 'sqlite:@app/runtime/test.db',
+    'charset' => 'utf8',
+];

--- a/controllers/ResultController.php
+++ b/controllers/ResultController.php
@@ -4,22 +4,15 @@ namespace app\controllers;
 
 use app\models\Result;
 use Yii;
-use yii\filters\auth\HttpBearerAuth;
 use yii\filters\VerbFilter;
-use yii\rest\Controller;
 use yii\web\ForbiddenHttpException;
 use yii\web\NotFoundHttpException;
 
-class ResultController extends Controller
+class ResultController extends ApiController
 {
     public function behaviors()
     {
         $b = parent::behaviors();
-
-        $b['authenticator'] = [
-            'class' => HttpBearerAuth::class,
-        ];
-
         $b['verbs'] = [
             'class' => VerbFilter::class,
             'actions' => [
@@ -97,7 +90,7 @@ class ResultController extends Controller
             Yii::$app->response->statusCode = 201;
             return $m->toArray([], ['assignee', 'setter']);
         }
-        Yii::$app->response->statusCode = 400;
+        Yii::$app->response->statusCode = 422;
         return ['errors' => $m->getErrors()];
     }
 

--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -3,20 +3,13 @@ namespace app\controllers;
 
 use app\models\User;
 use Yii;
-use yii\filters\auth\HttpBearerAuth;
 use yii\filters\VerbFilter;
-use yii\rest\Controller;
 
-class UserController extends Controller
+class UserController extends ApiController
 {
     public function behaviors()
     {
         $b = parent::behaviors();
-
-        $b['authenticator'] = [
-            'class' => HttpBearerAuth::class,
-        ];
-
         $b['verbs'] = [
             'class' => VerbFilter::class,
             'actions' => [
@@ -37,7 +30,7 @@ class UserController extends Controller
         }
 
         $fetch = function () use ($query) {
-            $rows = $query->orderBy(['id' => SORT_ASC])->asArray()->all();
+            $rows = $query->orderBy(['last_name' => SORT_ASC, 'first_name' => SORT_ASC, 'id' => SORT_ASC])->asArray()->all();
             return array_map(function ($u) {
                 return [
                     'id' => (int) $u['id'],

--- a/models/Result.php
+++ b/models/Result.php
@@ -43,6 +43,7 @@ class Result extends ActiveRecord
             [['title'], 'string', 'max' => 255],
             [['urgent'], 'boolean'],
             [['urgent'], 'default', 'value' => false],
+            [['assigned_to'], 'exist', 'targetClass' => User::class, 'targetAttribute' => ['assigned_to' => 'id'], 'message' => 'Відповідальний користувач не знайдений.'],
             [['parent_id'], 'validateParent'],
         ];
     }

--- a/tests/functional/ResultsApiCest.php
+++ b/tests/functional/ResultsApiCest.php
@@ -1,0 +1,56 @@
+<?php
+
+use app\models\User;
+
+class ResultsApiCest
+{
+    private string $token;
+
+    public function _before(FunctionalTester $I)
+    {
+        $user = User::findOne(1);
+        $this->token = $user->generateAccessToken(3600);
+    }
+
+    public function usersList(FunctionalTester $I)
+    {
+        $I->haveHttpHeader('Authorization', 'Bearer ' . $this->token);
+        $I->sendGET('/users', ['active' => 1]);
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+        $I->seeResponseContainsJson([
+            [
+                'id' => 1,
+                'first_name' => 'Admin',
+                'last_name' => 'User',
+                'username' => 'admin',
+            ],
+        ]);
+    }
+
+    public function createAndListResults(FunctionalTester $I)
+    {
+        $data = [
+            'title' => 'Api test',
+            'final_result' => 'Done',
+            'urgent' => true,
+            'description' => 'Desc',
+            'responsible_id' => 1,
+        ];
+
+        $I->haveHttpHeader('Authorization', 'Bearer ' . $this->token);
+        $I->sendPOST('/results', $data);
+        $I->seeResponseCodeIs(201);
+        $I->seeResponseContainsJson($data);
+
+        $I->haveHttpHeader('Authorization', 'Bearer ' . $this->token);
+        $I->sendGET('/results', ['page' => 1]);
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+        $I->seeResponseMatchesJsonType([
+            'meta' => ['page' => 'integer', 'perPage' => 'integer', 'total' => 'integer'],
+            'items' => 'array',
+        ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- serve `/users` via API controller with optional active filter and name sorting
- extend results API for creation and listing with proper verbs and error handling
- validate responsible user and cover endpoints with functional tests

## Testing
- `composer install` *(fails: Proxy CONNECT aborted due to timeout while downloading packages)*
- `php tests/bin/yii migrate/up --interactive=0` *(fails: Failed opening required 'vendor/yiisoft/yii2/Yii.php')*
- `vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b2153a79c8332b64bfb74cae5fd8d