### PR TITLE
Add CORS configuration and result completion update

### DIFF
--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -42,15 +42,13 @@ class ApiController extends Controller
                 // ВАЖЛИВО: локальний домен без https
                 'Origin' => [
                     'https://tasks.fineko.space',
-                    'http://ftasks.local',
                     'https://ftasks.local',
-                    // якщо треба dev CRA:
-                    // 'http://localhost:3000',
+                    'http://ftasks.local',
+                    'http://localhost:3000',
                 ],
                 'Access-Control-Request-Method' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-                'Access-Control-Request-Headers' => ['Authorization', 'Content-Type', 'X-Requested-With'],
-                // Ми не використовуємо cookies → креденшали не потрібні
-                'Access-Control-Allow-Credentials' => false,
+                'Access-Control-Request-Headers' => ['Authorization', 'Content-Type', 'Accept', 'Origin', 'X-Requested-With'],
+                'Access-Control-Allow-Credentials' => true,
                 'Access-Control-Max-Age' => 86400,
                 'Access-Control-Expose-Headers' => ['Content-Type'],
             ],
@@ -74,14 +72,14 @@ class ApiController extends Controller
             Yii::$app->response->statusCode = 200;
             // Додатково виставимо ACAO під конкретний Origin (на випадок, якщо сервер не прокинув)
             $origin = Yii::$app->request->headers->get('Origin');
-            $allowed = ['https://tasks.fineko.space', 'http://ftasks.local',  'https://ftasks.local'];
+            $allowed = ['https://tasks.fineko.space', 'https://ftasks.local', 'http://ftasks.local', 'http://localhost:3000'];
             if ($origin && in_array($origin, $allowed, true)) {
                 $h = Yii::$app->response->headers;
                 $h->set('Access-Control-Allow-Origin', $origin);
                 $h->set('Vary', 'Origin');
                 $h->set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
-                $h->set('Access-Control-Allow-Headers', 'Authorization, Content-Type, X-Requested-With');
-                // Креденшали не виставляємо, бо вони вимкнені
+                $h->set('Access-Control-Allow-Headers', 'Authorization, Content-Type, Accept, Origin, X-Requested-With');
+                $h->set('Access-Control-Allow-Credentials', 'true');
             }
             return false;
         }

--- a/controllers/ResultController.php
+++ b/controllers/ResultController.php
@@ -110,6 +110,19 @@ class ResultController extends ApiController
             $payload['urgent'] = (bool) $data['urgent'];
         }
 
+        if (array_key_exists('completed_at', $data)) {
+            if ($data['completed_at'] === null || $data['completed_at'] === '') {
+                $payload['completed_at'] = null;
+            } else {
+                $ts = strtotime($data['completed_at']);
+                if ($ts === false) {
+                    Yii::$app->response->statusCode = 422;
+                    return ['errors' => ['completed_at' => ['Invalid date format']]];
+                }
+                $payload['completed_at'] = $ts;
+            }
+        }
+
         $m->load($payload, '');
         if ($m->save()) {
             return $m->toArray([], ['assignee', 'setter']);

--- a/controllers/TaskController.php
+++ b/controllers/TaskController.php
@@ -4,21 +4,15 @@ namespace app\controllers;
 
 use backend\models\Task;
 use Yii;
-use yii\filters\auth\HttpBearerAuth;
 use yii\filters\VerbFilter;
-use yii\rest\Controller;
 use yii\web\ForbiddenHttpException;
 use yii\web\NotFoundHttpException;
 
-class TaskController extends Controller
+class TaskController extends ApiController
 {
     public function behaviors()
     {
         $b = parent::behaviors();
-
-        $b['authenticator'] = [
-            'class' => HttpBearerAuth::class,
-        ];
 
         $b['verbs'] = [
             'class' => VerbFilter::class,

--- a/models/Result.php
+++ b/models/Result.php
@@ -80,6 +80,9 @@ class Result extends ActiveRecord
         $fields['tasks_done'] = function () {
             return (int) $this->getTasks()->andWhere(['status' => 'done'])->count();
         };
+        $fields['completed_at'] = function () {
+            return $this->completed_at ? gmdate('c', $this->completed_at) : null;
+        };
         $fields['is_completed'] = function () {
             return $this->completed_at !== null;
         };


### PR DESCRIPTION
## Summary
- Enable CORS for production, local, and dev origins with credentials support
- Extend task endpoints from ApiController
- Allow updating result completion via PATCH and expose completion timestamp

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `php -l controllers/ApiController.php controllers/TaskController.php controllers/ResultController.php models/Result.php`

------
https://chatgpt.com/codex/tasks/task_e_689b2f93ce988332aa3140bbd31403f7