### PR TITLE
Handle missing urgent attribute in Result model

### DIFF
--- a/models/Result.php
+++ b/models/Result.php
@@ -48,6 +48,13 @@ class Result extends ActiveRecord
         ];
     }
 
+    public function attributes()
+    {
+        // Ensure "urgent" is recognized even if migrations adding the column
+        // haven't been applied yet to avoid Unknown Property errors.
+        return array_unique(array_merge(parent::attributes(), ['urgent']));
+    }
+
     public function validateParent($attribute)
     {
         if ($this->parent_id && (int) $this->parent_id === (int) $this->id) {


### PR DESCRIPTION
## Summary
- ensure Result model always recognizes the `urgent` attribute to prevent "Unknown Property" errors

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689b336207e883329b3f5dff05f16d4e