### PR TITLE
Return urgent flag as integer in Result responses

### DIFF
--- a/models/Result.php
+++ b/models/Result.php
@@ -66,7 +66,7 @@ class Result extends ActiveRecord
             return $this->assigned_to;
         };
         $fields['urgent'] = function () {
-            return (bool) $this->urgent;
+            return (int) (bool) $this->urgent;
         };
 
         unset($fields['expected_result'], $fields['assigned_to']);


### PR DESCRIPTION
## Summary
- cast Result urgent field to integer for consistent 0/1 API output

## Testing
- `vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b5f1e1f488332b616cb5d2be7ee08