### PR TITLE
Add urgent and due date handling for results

### DIFF
--- a/tests/functional/ResultsApiCest.php
+++ b/tests/functional/ResultsApiCest.php
@@ -33,7 +33,8 @@ class ResultsApiCest
         $data = [
             'title' => 'Api test',
             'final_result' => 'Done',
-            'urgent' => true,
+            'urgent' => 1,
+            'due_date' => '22.03.1993 12:32',
             'description' => 'Desc',
             'responsible_id' => 1,
         ];


### PR DESCRIPTION
## Summary
- support integer `urgent` flag and `due_date` datetime in `Result` model
- normalize `urgent` and map `responsible_id` in `ResultController`
- extend functional test for urgent and due date payload

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_689e04451908833293d7629479dd86f2