### PR TITLE
feat: support urgent flag for results

### DIFF
--- a/controllers/ResultController.php
+++ b/controllers/ResultController.php
@@ -78,7 +78,7 @@ class ResultController extends ApiController
 
         $m->load($data, '');
 
-        $m->urgent = !empty($m->urgent) ? 1 : 0;
+        $m->urgent = isset($data['urgent']) ? filter_var($data['urgent'], FILTER_VALIDATE_BOOLEAN) : false;
         if (isset($data['responsible_id'])) {
             $m->assigned_to = (int) $data['responsible_id'];
         }
@@ -103,7 +103,7 @@ class ResultController extends ApiController
 
         $m->load($data, '');
 
-        $m->urgent = !empty($m->urgent) ? 1 : 0;
+        $m->urgent = isset($data['urgent']) ? filter_var($data['urgent'], FILTER_VALIDATE_BOOLEAN) : false;
         if (isset($data['responsible_id'])) {
             $m->assigned_to = (int) $data['responsible_id'];
         }

--- a/migrations/m250814_170000_add_urgent_to_results.php
+++ b/migrations/m250814_170000_add_urgent_to_results.php
@@ -1,0 +1,25 @@
+<?php
+
+use yii\db\Migration;
+
+class m250814_170000_add_urgent_to_results extends Migration
+{
+    public function safeUp()
+    {
+        if ($this->db->schema->getTableSchema('{{%result}}', true) === null) {
+            throw new \RuntimeException('Table "result" not found.');
+        }
+
+        if ($this->db->schema->getTableSchema('{{%result}}')->getColumn('urgent') === null) {
+            $this->addColumn('{{%result}}', 'urgent', $this->tinyInteger(1)->notNull()->defaultValue(0)->after('expected_result'));
+        }
+    }
+
+    public function safeDown()
+    {
+        if ($this->db->schema->getTableSchema('{{%result}}', true) !== null &&
+            $this->db->schema->getTableSchema('{{%result}}')->getColumn('urgent') !== null) {
+            $this->dropColumn('{{%result}}', 'urgent');
+        }
+    }
+}

--- a/models/Result.php
+++ b/models/Result.php
@@ -12,10 +12,10 @@ use yii\db\ActiveRecord;
  * @property string $title
  * @property string|null $description
  * @property string|null $expected_result
- * @property int $urgent
-* @property int|null $assigned_to
-* @property int|null $setter_id
-* @property string|null $deadline        // DATE (Y-m-d)
+ * @property bool $urgent
+ * @property int|null $assigned_to
+ * @property int|null $setter_id
+ * @property string|null $deadline        // DATE (Y-m-d)
  * @property string|null $due_date       // DATETIME (Y-m-d H:i:s)
  * @property int|null $created_by
  * @property int|null $created_at
@@ -42,8 +42,8 @@ class Result extends ActiveRecord
             [['description', 'expected_result'], 'string'],
             [['deadline'], 'date', 'format' => 'php:Y-m-d'],
             [['title'], 'string', 'max' => 255],
+            [['urgent'], 'boolean'],
             [['urgent'], 'default', 'value' => 0],
-            [['urgent'], 'integer', 'min' => 0, 'max' => 1],
             [['due_date'], 'safe'],
             [['assigned_to'], 'exist', 'targetClass' => User::class, 'targetAttribute' => ['assigned_to' => 'id'], 'message' => 'Відповідальний користувач не знайдений.'],
             [['parent_id'], 'validateParent'],
@@ -68,7 +68,7 @@ class Result extends ActiveRecord
             return $this->assigned_to;
         };
         $fields['urgent'] = function () {
-            return (int) $this->urgent;
+            return (bool) $this->urgent;
         };
         $fields['due_date'] = function ($model) {
             if (empty($model->due_date)) {

--- a/tests/functional/ResultsApiCest.php
+++ b/tests/functional/ResultsApiCest.php
@@ -33,7 +33,7 @@ class ResultsApiCest
         $data = [
             'title' => 'Api test',
             'final_result' => 'Done',
-            'urgent' => 1,
+            'urgent' => true,
             'due_date' => '22.03.1993 12:32',
             'description' => 'Desc',
             'responsible_id' => 1,


### PR DESCRIPTION
## Summary
- add migration to introduce urgent column for results
- validate and expose urgent flag in Result model
- allow create/update endpoints to accept urgent
- adjust functional tests to check urgent flag

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e10004f248332b5210b8e575521e6