### PR TITLE
Add separate date field for results

### DIFF
--- a/migrations/m250822_120000_add_date_to_results.php
+++ b/migrations/m250822_120000_add_date_to_results.php
@@ -1,0 +1,28 @@
+<?php
+
+use yii\db\Migration;
+
+class m250822_120000_add_date_to_results extends Migration
+{
+    public function safeUp()
+    {
+        $this->addColumn('{{%result}}', 'date', $this->date()->after('expected_result'));
+        $this->createIndex('idx-result-date', '{{%result}}', 'date');
+        // Copy existing values from old deadline column if it exists
+        if ($this->db->getTableSchema('{{%result}}')->getColumn('deadline') !== null) {
+            $this->execute('UPDATE {{%result}} SET date = deadline');
+            $this->dropColumn('{{%result}}', 'deadline');
+        }
+    }
+
+    public function safeDown()
+    {
+        // restore old deadline column if needed
+        if ($this->db->getTableSchema('{{%result}}')->getColumn('deadline') === null) {
+            $this->addColumn('{{%result}}', 'deadline', $this->date()->after('expected_result'));
+            $this->execute('UPDATE {{%result}} SET deadline = date');
+        }
+        $this->dropIndex('idx-result-date', '{{%result}}');
+        $this->dropColumn('{{%result}}', 'date');
+    }
+}

--- a/models/search/ResultSearch.php
+++ b/models/search/ResultSearch.php
@@ -54,13 +54,13 @@ class ResultSearch extends Model
         }
 
         if ($this->dueFrom) {
-            $query->andWhere(['>=', 'deadline', $this->dueFrom]);
+            $query->andWhere(['>=', 'date', $this->dueFrom]);
         }
         if ($this->dueTo) {
-            $query->andWhere(['<=', 'deadline', $this->dueTo]);
+            $query->andWhere(['<=', 'date', $this->dueTo]);
         }
 
-        $query->orderBy(['deadline' => SORT_ASC, 'id' => SORT_DESC]);
+        $query->orderBy(['date' => SORT_ASC, 'id' => SORT_DESC]);
 
         $dataProvider = new ActiveDataProvider([
             'query' => $query,

--- a/tests/functional/ResultsApiCest.php
+++ b/tests/functional/ResultsApiCest.php
@@ -34,7 +34,8 @@ class ResultsApiCest
             'title' => 'Api test',
             'final_result' => 'Done',
             'urgent' => 1,
-            'due_date' => '22.03.1993 12:32',
+            'date' => '22.03.2099',
+            'due_date' => '22.03.2099 12:32',
             'description' => 'Desc',
             'responsible_id' => 1,
         ];


### PR DESCRIPTION
## Summary
- add `date` column to results and migrate existing `deadline` values
- validate and serialize `date` and `due_date` fields in results
- adjust search and functional tests for new date handling

## Testing
- `php -l migrations/m250822_120000_add_date_to_results.php`
- `php -l models/Result.php`
- `php -l models/search/ResultSearch.php`
- `php -l tests/functional/ResultsApiCest.php`
- `composer install` *(fails: requires GitHub token, unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_689e100ece908332acab6d41991711cb