### PR TITLE
feat: add toggle done endpoint

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -61,6 +61,7 @@ return [
                 'GET results' => 'result/index',
                 'POST results' => 'result/create',
                 'GET results/<id:\d+>' => 'result/view',
+                'PATCH results/<id:\d+>/toggle-done' => 'result/toggle-done',
                 'PATCH results/<id:\d+>' => 'result/update',
                 'DELETE results/<id:\d+>' => 'result/delete',
                 'POST results/<id:\d+>/complete' => 'result/complete',

--- a/controllers/ResultController.php
+++ b/controllers/ResultController.php
@@ -21,6 +21,7 @@ class ResultController extends ApiController
                 'create' => ['POST'],
                 'update' => ['PUT', 'PATCH'],
                 'delete' => ['DELETE'],
+                'toggle-done' => ['PATCH'],
             ],
         ];
 
@@ -129,6 +130,24 @@ class ResultController extends ApiController
         }
         Yii::$app->response->statusCode = 422;
         return ['errors' => $m->getErrors()];
+    }
+
+    public function actionToggleDone($id)
+    {
+        $m = $this->findModel((int) $id);
+        $this->ensureCanEdit($m);
+
+        $data = Yii::$app->request->post();
+
+        if (array_key_exists('is_done', $data)) {
+            $m->completed_at = filter_var($data['is_done'], FILTER_VALIDATE_BOOLEAN) ? time() : null;
+        } else {
+            $m->completed_at = $m->completed_at === null ? time() : null;
+        }
+
+        $m->save(false, ['completed_at', 'updated_at']);
+
+        return $m->toArray([], ['assignee', 'setter']);
     }
 
     public function actionDelete($id)

--- a/models/Result.php
+++ b/models/Result.php
@@ -119,6 +119,9 @@ class Result extends ActiveRecord
         $fields['is_completed'] = function () {
             return $this->completed_at !== null;
         };
+        $fields['is_done'] = function () {
+            return $this->completed_at !== null;
+        };
 
         return $fields;
     }


### PR DESCRIPTION
## Summary
- add PATCH `/results/{id}/toggle-done` endpoint to flip result completion
- expose `is_done` flag on results

## Testing
- `vendor/bin/codecept run` *(fails: vendor/bin/codecept not found)*
- `composer install` *(fails: curl error 56 while downloading https://api.github.com/)*

------
https://chatgpt.com/codex/tasks/task_e_689e1b9514488332ad8db26313b883f9