### PR TITLE
feat: add is_done flag to results

### DIFF
--- a/controllers/ResultController.php
+++ b/controllers/ResultController.php
@@ -79,6 +79,7 @@ class ResultController extends ApiController
         $m->load($data, '');
 
         $m->urgent = isset($data['urgent']) ? filter_var($data['urgent'], FILTER_VALIDATE_BOOLEAN) : false;
+        $m->is_done = isset($data['is_done']) ? filter_var($data['is_done'], FILTER_VALIDATE_BOOLEAN) : false;
         if (isset($data['responsible_id'])) {
             $m->assigned_to = (int) $data['responsible_id'];
         }
@@ -104,6 +105,9 @@ class ResultController extends ApiController
         $m->load($data, '');
 
         $m->urgent = isset($data['urgent']) ? filter_var($data['urgent'], FILTER_VALIDATE_BOOLEAN) : false;
+        if (array_key_exists('is_done', $data)) {
+            $m->is_done = filter_var($data['is_done'], FILTER_VALIDATE_BOOLEAN);
+        }
         if (isset($data['responsible_id'])) {
             $m->assigned_to = (int) $data['responsible_id'];
         }

--- a/migrations/m20250814_172622_add_is_done_to_results.php
+++ b/migrations/m20250814_172622_add_is_done_to_results.php
@@ -1,0 +1,16 @@
+<?php
+
+use yii\db\Migration;
+
+class m20250814_172622_add_is_done_to_results extends Migration
+{
+    public function safeUp()
+    {
+        $this->addColumn('{{%result}}', 'is_done', $this->tinyInteger()->notNull()->defaultValue(0)->after('completed_at'));
+    }
+
+    public function safeDown()
+    {
+        $this->dropColumn('{{%result}}', 'is_done');
+    }
+}

--- a/models/Result.php
+++ b/models/Result.php
@@ -13,6 +13,7 @@ use yii\db\ActiveRecord;
  * @property string|null $description
  * @property string|null $expected_result
  * @property int $urgent
+ * @property int $is_done
 * @property int|null $assigned_to
 * @property int|null $setter_id
  * @property string|null $date           // DATE (Y-m-d)
@@ -42,9 +43,9 @@ class Result extends ActiveRecord
             [['description', 'expected_result'], 'string'],
             [['date'], 'date', 'format' => 'php:d.m.Y'],
             [['title'], 'string', 'max' => 255],
-            [['urgent'], 'boolean'],
-            [['urgent'], 'default', 'value' => 0],
-            [['urgent'], 'integer', 'min' => 0, 'max' => 1],
+            [['urgent', 'is_done'], 'boolean'],
+            [['urgent', 'is_done'], 'default', 'value' => 0],
+            [['urgent', 'is_done'], 'integer', 'min' => 0, 'max' => 1],
             [['due_date', 'date'], 'safe'],
             [['due_date'], 'validateNotPast'],
             [['date'], 'validateNotPast'],
@@ -86,6 +87,9 @@ class Result extends ActiveRecord
         };
         $fields['urgent'] = function () {
             return (bool) $this->urgent;
+        };
+        $fields['is_done'] = function () {
+            return (bool) $this->is_done;
         };
         $fields['due_date'] = function ($model) {
             if (empty($model->due_date)) {


### PR DESCRIPTION
## Summary
- add boolean is_done column to results
- expose is_done in Result model and API controller

## Testing
- `composer install` *(fails: Failed to download yiisoft/yii2-composer... CONNECT tunnel failed, response 403)*
- `php -l models/Result.php controllers/ResultController.php migrations/m20250814_172622_add_is_done_to_results.php`

------
https://chatgpt.com/codex/tasks/task_e_689e1b892c608332a95e21f4d75fd223