### PR TITLE
Allow unauthenticated access to task filter and templates

### DIFF
--- a/controllers/TaskController.php
+++ b/controllers/TaskController.php
@@ -2,7 +2,7 @@
 
 namespace app\controllers;
 
-use backend\models\Task;
+use app\models\Task;
 use Yii;
 use yii\filters\VerbFilter;
 use yii\web\BadRequestHttpException;
@@ -11,6 +11,14 @@ use yii\web\NotFoundHttpException;
 
 class TaskController extends ApiController
 {
+    /**
+     * Дії, які доступні без Bearer-автентифікації.
+     */
+    protected function authExcept(): array
+    {
+        return array_merge(parent::authExcept(), ['filter', 'templates']);
+    }
+
     public function behaviors()
     {
         $b = parent::behaviors();


### PR DESCRIPTION
## Summary
- allow unauthenticated access for `tasks/filter` and `tasks/templates` endpoints
- fix Task model namespace in TaskController

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e3618c6708332991bdd490ecd50a9