### PR TITLE
Allow POST requests for daily tasks endpoint

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -69,7 +69,7 @@ return [
 
                 'GET tasks/filter' => 'task/filter',
                 'GET tasks/templates' => 'task/templates',
-                'GET tasks/daily' => 'task/daily',
+                'GET,POST tasks/daily' => 'task/daily',
                 'GET tasks' => 'task/index',
                 'GET tasks/<id:\d+>' => 'task/view',
                 'POST tasks' => 'task/create',

--- a/controllers/TaskController.php
+++ b/controllers/TaskController.php
@@ -25,7 +25,7 @@ class TaskController extends ApiController
                 'delete' => ['DELETE'],
                 'filter' => ['GET'],
                 'templates' => ['GET'],
-                'daily' => ['GET'],
+                'daily' => ['GET', 'POST'],
             ],
         ];
 


### PR DESCRIPTION
## Summary
- accept POST requests on `/tasks/daily`
- permit POST method via router and controller verb filter

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e3808abf483329a865752bc8f4986