### PR TITLE
Add instructions endpoint with CORS

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -73,6 +73,8 @@ return [
                 'POST auth/request-password-reset' => 'auth/request-password-reset',
                 'POST auth/reset-password' => 'auth/reset-password',
 
+                'GET instructions' => 'instruction/index',
+
                 'GET users' => 'user/index',
 
                 'GET results' => 'result/index',

--- a/controllers/InstructionController.php
+++ b/controllers/InstructionController.php
@@ -1,0 +1,39 @@
+<?php
+namespace app\controllers;
+
+use Yii;
+
+/**
+ * Віддає інструкції для фронтенду.
+ */
+class InstructionController extends ApiController
+{
+    /**
+     * Дії, які доступні без Bearer-автентифікації.
+     */
+    protected function authExcept(): array
+    {
+        return array_merge(parent::authExcept(), ['index']);
+    }
+
+    public function verbs()
+    {
+        return array_merge(parent::verbs(), [
+            'index' => ['GET'],
+        ]);
+    }
+
+    /**
+     * GET /instructions
+     * Повертає вміст файлу AI_RULES.md
+     */
+    public function actionIndex()
+    {
+        $file = Yii::getAlias('@app/AI_RULES.md');
+        if (!is_file($file)) {
+            Yii::$app->response->statusCode = 404;
+            return ['error' => 'Instructions file not found'];
+        }
+        return ['content' => file_get_contents($file)];
+    }
+}


### PR DESCRIPTION
## Summary
- add InstructionController to serve instructions from `AI_RULES.md`
- route GET /instructions to new controller

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689e3c68b2008332aa85053f2b0ab171