### PR TITLE
feat: scaffold telegram integration

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -94,6 +94,9 @@ return [
                 'PUT,PATCH tasks/<id:\d+>' => 'task/update',
                 'DELETE tasks/<id:\d+>' => 'task/delete',
 
+                'POST telegram/webhook' => 'telegram/webhook',
+                'GET telegram/health' => 'telegram/health',
+
                 // catch‑all preflight
                 ['pattern' => '<path:.*>', 'route' => 'site/options', 'verb' => 'OPTIONS'],
             ],

--- a/controllers/TelegramController.php
+++ b/controllers/TelegramController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace app\controllers;
+
+use app\services\AiTaskExtractor;
+use app\services\ResultService;
+use Yii;
+use yii\filters\VerbFilter;
+use yii\web\BadRequestHttpException;
+
+class TelegramController extends ApiController
+{
+    public function behaviors()
+    {
+        $b = parent::behaviors();
+        $b['verbs'] = [
+            'class' => VerbFilter::class,
+            'actions' => [
+                'webhook' => ['POST'],
+                'health' => ['GET'],
+            ],
+        ];
+        return $b;
+    }
+
+    public function actionWebhook()
+    {
+        $data = Yii::$app->request->getBodyParams();
+        if (empty($data)) {
+            throw new BadRequestHttpException('Empty payload');
+        }
+
+        // placeholder logic
+        $text = $data['message']['text'] ?? '';
+        $chatId = $data['message']['chat']['id'] ?? null;
+        if (!$chatId) {
+            return ['ok' => false];
+        }
+
+        $ai = new AiTaskExtractor();
+        $resultService = new ResultService();
+        $aiData = $ai->extract(0, $text, []);
+        if (($aiData['is_task'] ?? false) && empty($aiData['missing'])) {
+            $result = $resultService->createFromTelegram($aiData);
+            return ['ok' => true, 'result_id' => $result ? $result->id : null];
+        }
+
+        return ['ok' => true];
+    }
+
+    public function actionHealth()
+    {
+        return ['status' => 'ok'];
+    }
+}

--- a/migrations/m250901_000000_create_telegram_tables.php
+++ b/migrations/m250901_000000_create_telegram_tables.php
@@ -1,0 +1,72 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation of tables related to Telegram integration.
+ */
+class m250901_000000_create_telegram_tables extends Migration
+{
+    public function safeUp()
+    {
+        // telegram_groups
+        $this->createTable('telegram_groups', [
+            'id' => $this->primaryKey(),
+            'company_id' => $this->integer()->notNull(),
+            'chat_id' => $this->bigInteger()->notNull(),
+            'title' => $this->string()->notNull(),
+            'added_by_user_id' => $this->integer(),
+            'is_active' => $this->boolean()->defaultValue(true),
+            'created_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('idx-telegram_groups-chat_id', 'telegram_groups', 'chat_id');
+        $this->createIndex('idx-telegram_groups-company_id', 'telegram_groups', 'company_id');
+
+        // telegram_aliases
+        $this->createTable('telegram_aliases', [
+            'id' => $this->primaryKey(),
+            'company_id' => $this->integer()->notNull(),
+            'employee_id' => $this->integer()->notNull(),
+            'telegram_user_id' => $this->bigInteger(),
+            'username' => $this->string(),
+            'display_name' => $this->string(),
+            'synonyms' => $this->json(),
+            'is_active' => $this->boolean()->defaultValue(true),
+            'created_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('idx-telegram_aliases-company_id', 'telegram_aliases', 'company_id');
+        $this->createIndex('idx-telegram_aliases-telegram_user_id', 'telegram_aliases', 'telegram_user_id');
+
+        // telegram_conversations
+        $this->createTable('telegram_conversations', [
+            'id' => $this->primaryKey(),
+            'chat_id' => $this->bigInteger()->notNull(),
+            'thread_key' => $this->bigInteger()->notNull(),
+            'company_id' => $this->integer()->notNull(),
+            'state' => $this->json(),
+            'expires_at' => $this->integer(),
+            'updated_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('idx-telegram_conversations-chat_id', 'telegram_conversations', 'chat_id');
+        $this->createIndex('idx-telegram_conversations-company_id', 'telegram_conversations', 'company_id');
+
+        // telegram_messages_log
+        $this->createTable('telegram_messages_log', [
+            'id' => $this->primaryKey(),
+            'chat_id' => $this->bigInteger()->notNull(),
+            'from_user_id' => $this->bigInteger(),
+            'message_id' => $this->bigInteger()->notNull(),
+            'payload' => $this->json(),
+            'created_at' => $this->integer()->notNull(),
+        ]);
+        $this->createIndex('idx-telegram_messages_log-chat_id', 'telegram_messages_log', 'chat_id');
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('telegram_messages_log');
+        $this->dropTable('telegram_conversations');
+        $this->dropTable('telegram_aliases');
+        $this->dropTable('telegram_groups');
+    }
+}

--- a/models/TelegramAlias.php
+++ b/models/TelegramAlias.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+/**
+ * @property int $id
+ * @property int $company_id
+ * @property int $employee_id
+ * @property int|null $telegram_user_id
+ * @property string|null $username
+ * @property string|null $display_name
+ * @property array|null $synonyms
+ * @property bool $is_active
+ * @property int $created_at
+ */
+class TelegramAlias extends ActiveRecord
+{
+    public static function tableName(): string
+    {
+        return 'telegram_aliases';
+    }
+}

--- a/models/TelegramConversation.php
+++ b/models/TelegramConversation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+/**
+ * @property int $id
+ * @property int $chat_id
+ * @property int $thread_key
+ * @property int $company_id
+ * @property array|null $state
+ * @property int|null $expires_at
+ * @property int $updated_at
+ */
+class TelegramConversation extends ActiveRecord
+{
+    public static function tableName(): string
+    {
+        return 'telegram_conversations';
+    }
+}

--- a/models/TelegramGroup.php
+++ b/models/TelegramGroup.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+/**
+ * @property int $id
+ * @property int $company_id
+ * @property int $chat_id
+ * @property string $title
+ * @property int|null $added_by_user_id
+ * @property bool $is_active
+ * @property int $created_at
+ */
+class TelegramGroup extends ActiveRecord
+{
+    public static function tableName(): string
+    {
+        return 'telegram_groups';
+    }
+}

--- a/models/TelegramMessageLog.php
+++ b/models/TelegramMessageLog.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+/**
+ * @property int $id
+ * @property int $chat_id
+ * @property int|null $from_user_id
+ * @property int $message_id
+ * @property array|null $payload
+ * @property int $created_at
+ */
+class TelegramMessageLog extends ActiveRecord
+{
+    public static function tableName(): string
+    {
+        return 'telegram_messages_log';
+    }
+}

--- a/services/AiTaskExtractor.php
+++ b/services/AiTaskExtractor.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace app\services;
+
+use Yii;
+use yii\httpclient\Client;
+
+class AiTaskExtractor
+{
+    /**
+     * Calls OpenAI API to extract task fields from given text.
+     *
+     * @param int $companyId
+     * @param string $text
+     * @param array $context
+     * @return array
+     */
+    public function extract(int $companyId, string $text, array $context = []): array
+    {
+        $client = new Client(['baseUrl' => 'https://api.openai.com/v1']);
+        $apiKey = Yii::$app->params['openaiApiKey'] ?? null;
+        if (!$apiKey) {
+            return ['is_task' => false, 'missing' => ['openaiApiKey']];
+        }
+
+        $response = $client->post('chat/completions', [
+            'model' => 'gpt-3.5-turbo-0125',
+            'messages' => [
+                ['role' => 'system', 'content' => 'You are a task extraction assistant.'],
+                ['role' => 'user', 'content' => $text],
+            ],
+        ])->addHeaders([
+            'Authorization' => 'Bearer ' . $apiKey,
+        ])->send();
+
+        if (!$response->isOk) {
+            Yii::error('OpenAI error: ' . $response->content, 'application');
+            return ['is_task' => false, 'missing' => ['openai']];
+        }
+
+        // This is a placeholder. In production parse $response->data
+        return $response->data['choices'][0]['message']['content'] ?? [];
+    }
+}

--- a/services/ResultService.php
+++ b/services/ResultService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace app\services;
+
+use app\models\Result;
+use Yii;
+
+class ResultService
+{
+    /**
+     * Creates a Result from Telegram parsed data.
+     *
+     * @param array $data
+     * @return Result|null
+     */
+    public function createFromTelegram(array $data): ?Result
+    {
+        $m = new Result();
+        $m->name = $data['title'] ?? 'Untitled';
+        $m->description = $data['description'] ?? '';
+        if (isset($data['assignee_id'])) {
+            $m->assigned_to = (int) $data['assignee_id'];
+        }
+        if (isset($data['due_date'])) {
+            $ts = strtotime($data['due_date']);
+            if ($ts !== false) {
+                $m->due_date = $ts;
+            }
+        }
+        $m->urgent = (bool) ($data['urgent'] ?? false);
+        $m->priority = $data['priority'] ?? null;
+        $m->created_at = time();
+        $m->updated_at = time();
+        $m->setter_id = Yii::$app->user->id ?? null;
+
+        if ($m->save()) {
+            return $m;
+        }
+        Yii::error('Failed to save result: ' . json_encode($m->errors), 'application');
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Telegram webhook controller and routes
- add migrations and models for Telegram tables
- add service stubs for AI task extraction and Result creation

## Testing
- `composer install` *(fails: requires GitHub token)*
- `vendor/bin/codecept run` *(fails: vendor/bin/codecept not found)*
- `php yii migrate/up --migrationPath=@app/migrations --interactive=0` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e41b051c08332903bc9b7468aa2d9