### PR TITLE
Handle result completion without is_done column

### DIFF
--- a/controllers/ResultController.php
+++ b/controllers/ResultController.php
@@ -80,7 +80,10 @@ class ResultController extends ApiController
         $m->load($data, '');
 
         $m->urgent = isset($data['urgent']) ? filter_var($data['urgent'], FILTER_VALIDATE_BOOLEAN) : false;
-        $m->is_done = isset($data['is_done']) ? filter_var($data['is_done'], FILTER_VALIDATE_BOOLEAN) : false;
+        if (array_key_exists('is_done', $data) || array_key_exists('is_completed', $data)) {
+            $flag = array_key_exists('is_done', $data) ? $data['is_done'] : $data['is_completed'];
+            $m->completed_at = filter_var($flag, FILTER_VALIDATE_BOOLEAN) ? time() : null;
+        }
         if (isset($data['responsible_id'])) {
             $m->assigned_to = (int) $data['responsible_id'];
         }
@@ -106,8 +109,9 @@ class ResultController extends ApiController
         $m->load($data, '');
 
         $m->urgent = isset($data['urgent']) ? filter_var($data['urgent'], FILTER_VALIDATE_BOOLEAN) : false;
-        if (array_key_exists('is_done', $data)) {
-            $m->is_done = filter_var($data['is_done'], FILTER_VALIDATE_BOOLEAN);
+        if (array_key_exists('is_done', $data) || array_key_exists('is_completed', $data)) {
+            $flag = array_key_exists('is_done', $data) ? $data['is_done'] : $data['is_completed'];
+            $m->completed_at = filter_var($flag, FILTER_VALIDATE_BOOLEAN) ? ($m->completed_at ?? time()) : null;
         }
         if (isset($data['responsible_id'])) {
             $m->assigned_to = (int) $data['responsible_id'];
@@ -143,8 +147,9 @@ class ResultController extends ApiController
 
         $data = Yii::$app->request->post();
 
-        if (array_key_exists('is_done', $data)) {
-            $m->completed_at = filter_var($data['is_done'], FILTER_VALIDATE_BOOLEAN) ? time() : null;
+        if (array_key_exists('is_done', $data) || array_key_exists('is_completed', $data)) {
+            $flag = array_key_exists('is_done', $data) ? $data['is_done'] : $data['is_completed'];
+            $m->completed_at = filter_var($flag, FILTER_VALIDATE_BOOLEAN) ? time() : null;
         } else {
             $m->completed_at = $m->completed_at === null ? time() : null;
         }

--- a/models/Result.php
+++ b/models/Result.php
@@ -13,9 +13,8 @@ use yii\db\ActiveRecord;
  * @property string|null $description
  * @property string|null $expected_result
  * @property int $urgent
- * @property int $is_done
-* @property int|null $assigned_to
-* @property int|null $setter_id
+ * @property int|null $assigned_to
+ * @property int|null $setter_id
  * @property string|null $date           // DATE (Y-m-d)
  * @property string|null $due_date       // DATETIME (Y-m-d H:i:s)
  * @property int|null $created_by
@@ -43,9 +42,9 @@ class Result extends ActiveRecord
             [['description', 'expected_result'], 'string'],
             [['date'], 'date', 'format' => 'php:d.m.Y'],
             [['title'], 'string', 'max' => 255],
-            [['urgent', 'is_done'], 'boolean'],
-            [['urgent', 'is_done'], 'default', 'value' => 0],
-            [['urgent', 'is_done'], 'integer', 'min' => 0, 'max' => 1],
+            [['urgent'], 'boolean'],
+            [['urgent'], 'default', 'value' => 0],
+            [['urgent'], 'integer', 'min' => 0, 'max' => 1],
             [['due_date', 'date'], 'safe'],
             [['due_date'], 'validateNotPast'],
             [['date'], 'validateNotPast'],
@@ -87,9 +86,6 @@ class Result extends ActiveRecord
         };
         $fields['urgent'] = function () {
             return (bool) $this->urgent;
-        };
-        $fields['is_done'] = function () {
-            return (bool) $this->is_done;
         };
         $fields['due_date'] = function ($model) {
             if (empty($model->due_date)) {


### PR DESCRIPTION
## Summary
- derive result completion from `completed_at` instead of `is_done`
- support `is_completed` flag when creating, updating or toggling results

## Testing
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_689e3d8b417483328f67baf870b71ce4