### PR TITLE
Fix urgent flag handling in results update

### DIFF
--- a/controllers/ResultController.php
+++ b/controllers/ResultController.php
@@ -79,7 +79,9 @@ class ResultController extends ApiController
 
         $m->load($data, '');
 
-        $m->urgent = isset($data['urgent']) ? filter_var($data['urgent'], FILTER_VALIDATE_BOOLEAN) : false;
+        if (array_key_exists('urgent', $data)) {
+            $m->urgent = filter_var($data['urgent'], FILTER_VALIDATE_BOOLEAN) ? 1 : 0;
+        }
         if (array_key_exists('is_done', $data) || array_key_exists('is_completed', $data)) {
             $flag = array_key_exists('is_done', $data) ? $data['is_done'] : $data['is_completed'];
             $m->completed_at = filter_var($flag, FILTER_VALIDATE_BOOLEAN) ? time() : null;
@@ -108,7 +110,9 @@ class ResultController extends ApiController
 
         $m->load($data, '');
 
-        $m->urgent = isset($data['urgent']) ? filter_var($data['urgent'], FILTER_VALIDATE_BOOLEAN) : false;
+        if (array_key_exists('urgent', $data)) {
+            $m->urgent = filter_var($data['urgent'], FILTER_VALIDATE_BOOLEAN) ? 1 : 0;
+        }
         if (array_key_exists('is_done', $data) || array_key_exists('is_completed', $data)) {
             $flag = array_key_exists('is_done', $data) ? $data['is_done'] : $data['is_completed'];
             $m->completed_at = filter_var($flag, FILTER_VALIDATE_BOOLEAN) ? ($m->completed_at ?? time()) : null;


### PR DESCRIPTION
## Summary
- ensure urgent flag is only updated when provided and cast to integer

## Testing
- `php -l controllers/ResultController.php`
- `composer install --no-interaction --no-progress` *(fails: unable to clone dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689e48a3f740833299fa51fd2f0b68ae