### PR TITLE
Add instruction table and seed tasks for upcoming days

### DIFF
--- a/migrations/m250902_000000_create_instruction_table.php
+++ b/migrations/m250902_000000_create_instruction_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation of table `{{%instruction}}`.
+ */
+class m250902_000000_create_instruction_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%instruction}}', [
+            'id' => $this->primaryKey(),
+            'organization_id' => $this->integer()->notNull(),
+            'title' => $this->string()->notNull(),
+            'content' => $this->text()->notNull(),
+            'created_at' => $this->integer(),
+            'updated_at' => $this->integer(),
+        ]);
+
+        $this->addForeignKey(
+            'fk_instruction_organization',
+            '{{%instruction}}',
+            'organization_id',
+            '{{%organization}}',
+            'id',
+            'CASCADE'
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_instruction_organization', '{{%instruction}}');
+        $this->dropTable('{{%instruction}}');
+    }
+}

--- a/migrations/m250902_000100_seed_instructions_and_tasks.php
+++ b/migrations/m250902_000100_seed_instructions_and_tasks.php
@@ -1,0 +1,120 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Seeds initial instructions and tasks.
+ */
+class m250902_000100_seed_instructions_and_tasks extends Migration
+{
+    public function safeUp()
+    {
+        $time = time();
+
+        // instructions
+        $this->insert('{{%instruction}}', [
+            'organization_id' => 1,
+            'title' => 'Getting Started',
+            'content' => 'Use this app to manage your tasks.',
+            'created_at' => $time,
+            'updated_at' => $time,
+        ]);
+
+        $this->insert('{{%instruction}}', [
+            'organization_id' => 1,
+            'title' => 'Reporting',
+            'content' => 'Report progress daily via the app.',
+            'created_at' => $time,
+            'updated_at' => $time,
+        ]);
+
+        // tasks
+        $today = date('Y-m-d');
+        $tomorrow = date('Y-m-d', strtotime('+1 day'));
+        $afterTomorrow = date('Y-m-d', strtotime('+2 days'));
+        $nextWeek = date('Y-m-d', strtotime('+7 days'));
+
+        $this->insert('{{%task}}', [
+            'organization_id' => 1,
+            'result_id' => null,
+            'title' => 'Task for today',
+            'expected_result' => "Complete today's task",
+            'result' => null,
+            'type' => 'normal',
+            'assigned_by' => 1,
+            'assigned_to' => 1,
+            'expected_time' => 60,
+            'actual_time' => null,
+            'planned_date' => $today,
+            'status' => 'new',
+            'created_at' => $time,
+            'updated_at' => $time,
+        ]);
+
+        $this->insert('{{%task}}', [
+            'organization_id' => 1,
+            'result_id' => null,
+            'title' => 'Task for tomorrow',
+            'expected_result' => "Complete tomorrow's task",
+            'result' => null,
+            'type' => 'normal',
+            'assigned_by' => 1,
+            'assigned_to' => 1,
+            'expected_time' => 60,
+            'actual_time' => null,
+            'planned_date' => $tomorrow,
+            'status' => 'new',
+            'created_at' => $time,
+            'updated_at' => $time,
+        ]);
+
+        $this->insert('{{%task}}', [
+            'organization_id' => 1,
+            'result_id' => null,
+            'title' => 'Task for day after tomorrow',
+            'expected_result' => "Complete day after tomorrow's task",
+            'result' => null,
+            'type' => 'normal',
+            'assigned_by' => 1,
+            'assigned_to' => 1,
+            'expected_time' => 60,
+            'actual_time' => null,
+            'planned_date' => $afterTomorrow,
+            'status' => 'new',
+            'created_at' => $time,
+            'updated_at' => $time,
+        ]);
+
+        $this->insert('{{%task}}', [
+            'organization_id' => 1,
+            'result_id' => null,
+            'title' => 'Task for next week',
+            'expected_result' => 'Complete next week\'s task',
+            'result' => null,
+            'type' => 'normal',
+            'assigned_by' => 1,
+            'assigned_to' => 1,
+            'expected_time' => 60,
+            'actual_time' => null,
+            'planned_date' => $nextWeek,
+            'status' => 'new',
+            'created_at' => $time,
+            'updated_at' => $time,
+        ]);
+    }
+
+    public function safeDown()
+    {
+        $this->delete('{{%task}}', ['title' => [
+            'Task for today',
+            'Task for tomorrow',
+            'Task for day after tomorrow',
+            'Task for next week',
+        ]]);
+
+        $this->delete('{{%instruction}}', ['title' => [
+            'Getting Started',
+            'Reporting',
+        ]]);
+    }
+}


### PR DESCRIPTION
## Summary
- add migration creating instruction table with organization link
- seed initial instructions and tasks for today, tomorrow, day after tomorrow and next week

## Testing
- `composer install --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e4930410c8332922ff6685daedd30