### PR TITLE
Add business process creation endpoint

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -95,6 +95,7 @@ return [
                 'POST tasks' => 'task/create',
                 'PUT,PATCH tasks/<id:\d+>' => 'task/update',
                 'DELETE tasks/<id:\d+>' => 'task/delete',
+                'POST business-processes' => 'business-process/create',
 
                 'POST telegram/webhook' => 'telegram/webhook',
                 'GET telegram/health' => 'telegram/health',

--- a/controllers/BusinessProcessController.php
+++ b/controllers/BusinessProcessController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace app\controllers;
+
+use app\models\BusinessProcess;
+use Yii;
+use yii\filters\VerbFilter;
+
+class BusinessProcessController extends ApiController
+{
+    public function behaviors()
+    {
+        $b = parent::behaviors();
+        $b['verbs'] = [
+            'class' => VerbFilter::class,
+            'actions' => [
+                'create' => ['POST'],
+            ],
+        ];
+        return $b;
+    }
+
+    public function actionCreate()
+    {
+        $model = new BusinessProcess();
+        $model->load(Yii::$app->request->post(), '');
+        if ($model->save()) {
+            Yii::$app->response->statusCode = 201;
+            return $model;
+        }
+        Yii::$app->response->statusCode = 422;
+        return ['errors' => $model->getErrors()];
+    }
+}

--- a/migrations/m250814_000400_create_business_process_table.php
+++ b/migrations/m250814_000400_create_business_process_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation of table `{{%business_process}}`.
+ */
+class m250814_000400_create_business_process_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%business_process}}', [
+            'id' => $this->primaryKey(),
+            'name' => $this->string(255)->notNull(),
+            'schema' => $this->text()->notNull(),
+            'created_at' => $this->integer(),
+            'updated_at' => $this->integer(),
+        ]);
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('{{%business_process}}');
+    }
+}

--- a/models/BusinessProcess.php
+++ b/models/BusinessProcess.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class BusinessProcess extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return '{{%business_process}}';
+    }
+
+    public function rules()
+    {
+        return [
+            [['name', 'schema'], 'required'],
+            [['schema'], 'safe'],
+            [['name'], 'string', 'max' => 255],
+        ];
+    }
+
+    public function fields()
+    {
+        $fields = parent::fields();
+        $fields['schema'] = function ($model) {
+            if (is_string($model->schema)) {
+                $decoded = json_decode($model->schema, true);
+                return $decoded === null ? $model->schema : $decoded;
+            }
+            return $model->schema;
+        };
+        return $fields;
+    }
+
+    public function beforeSave($insert)
+    {
+        if (is_array($this->schema)) {
+            $this->schema = json_encode($this->schema);
+        }
+        $now = time();
+        if ($insert) {
+            $this->created_at = $now;
+        }
+        $this->updated_at = $now;
+        return parent::beforeSave($insert);
+    }
+}

--- a/tests/functional/BusinessProcessApiCest.php
+++ b/tests/functional/BusinessProcessApiCest.php
@@ -1,0 +1,31 @@
+<?php
+
+use app\models\User;
+
+class BusinessProcessApiCest
+{
+    private string $token;
+
+    public function _before(FunctionalTester $I)
+    {
+        $user = User::findOne(1);
+        $this->token = $user->generateAccessToken(3600);
+    }
+
+    public function createBusinessProcess(FunctionalTester $I)
+    {
+        $data = [
+            'name' => 'Новий бізнес‑процес',
+            'schema' => [
+                'lanes' => [],
+                'nodes' => [],
+                'edges' => [],
+            ],
+        ];
+
+        $I->haveHttpHeader('Authorization', 'Bearer ' . $this->token);
+        $I->sendPOST('/business-processes', $data);
+        $I->seeResponseCodeIs(201);
+        $I->seeResponseContainsJson($data);
+    }
+}


### PR DESCRIPTION
## Summary
- add BusinessProcess model and migration
- expose POST /business-processes to create business processes
- cover creation with functional test

## Testing
- `vendor/bin/codecept run` *(fails: vendor/bin/codecept: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e4989e4c48332887bc20f359427c4