### PR TITLE
Add GPT controller with audio transcription endpoints

### DIFF
--- a/controllers/GptController.php
+++ b/controllers/GptController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace app\controllers;
+
+use Yii;
+use yii\web\BadRequestHttpException;
+use yii\web\UploadedFile;
+use app\services\AiAudioTranscriber;
+use app\services\AiJsonExtractor;
+
+/**
+ * Controller for interacting with OpenAI (GPT) services.
+ */
+class GptController extends ApiController
+{
+    private AiAudioTranscriber $transcriber;
+    private AiJsonExtractor $extractor;
+
+    public function __construct($id, $module, $config = [])
+    {
+        $this->transcriber = new AiAudioTranscriber();
+        $this->extractor = new AiJsonExtractor();
+        parent::__construct($id, $module, $config);
+    }
+
+    public function verbs()
+    {
+        return array_merge(parent::verbs(), [
+            'audio-task' => ['POST'],
+            'audio-result' => ['POST'],
+            'audio-template' => ['POST'],
+            'text-task' => ['POST'],
+        ]);
+    }
+
+    private function transcribeFile(): string
+    {
+        $file = UploadedFile::getInstanceByName('file');
+        if (!$file) {
+            throw new BadRequestHttpException('File is required');
+        }
+        $text = $this->transcriber->transcribe($file);
+        if ($text === '') {
+            throw new BadRequestHttpException('Unable to transcribe audio');
+        }
+        return $text;
+    }
+
+    /**
+     * Converts audio to task JSON.
+     */
+    public function actionAudioTask()
+    {
+        $text = $this->transcribeFile();
+        return $this->extractor->extract($text, 'Extract task fields from the text and return them as JSON.');
+    }
+
+    /**
+     * Converts audio to result JSON.
+     */
+    public function actionAudioResult()
+    {
+        $text = $this->transcribeFile();
+        return $this->extractor->extract($text, 'Extract task result fields from the text and return them as JSON.');
+    }
+
+    /**
+     * Converts audio to task template JSON.
+     */
+    public function actionAudioTemplate()
+    {
+        $text = $this->transcribeFile();
+        return $this->extractor->extract($text, 'Extract task template fields from the text and return them as JSON.');
+    }
+
+    /**
+     * Checks whether given text describes a task and returns task JSON if so.
+     */
+    public function actionTextTask()
+    {
+        $text = Yii::$app->request->post('text', '');
+        if ($text === '') {
+            throw new BadRequestHttpException('Parameter "text" is required');
+        }
+        $data = $this->extractor->extract(
+            $text,
+            'Determine if the user text describes a task. If yes, respond with {"is_task":true, ...task fields...}. If not, respond with {"is_task":false}.'
+        );
+        if (!($data['is_task'] ?? false)) {
+            return [];
+        }
+        return $data;
+    }
+}

--- a/services/AiAudioTranscriber.php
+++ b/services/AiAudioTranscriber.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace app\services;
+
+use Yii;
+use yii\httpclient\Client;
+use yii\web\UploadedFile;
+
+/**
+ * Service that sends audio files to OpenAI and returns transcribed text.
+ */
+class AiAudioTranscriber
+{
+    /**
+     * Transcribe given audio file via OpenAI API.
+     *
+     * @param UploadedFile $file
+     * @return string Transcribed text or empty string on failure.
+     */
+    public function transcribe(UploadedFile $file): string
+    {
+        $apiKey = Yii::$app->params['openaiApiKey'] ?? null;
+        if (!$apiKey) {
+            return '';
+        }
+
+        $client = new Client(['baseUrl' => 'https://api.openai.com/v1']);
+        $request = $client->createRequest()
+            ->setMethod('POST')
+            ->setUrl('audio/transcriptions')
+            ->addHeaders(['Authorization' => 'Bearer ' . $apiKey])
+            ->addFile('file', $file->tempName, $file->type, $file->name)
+            ->setData(['model' => 'gpt-4o-mini-transcribe']);
+
+        $response = $request->send();
+        if (!$response->isOk) {
+            Yii::error('OpenAI transcription error: ' . $response->content, 'application');
+            return '';
+        }
+
+        return $response->data['text'] ?? '';
+    }
+}

--- a/services/AiJsonExtractor.php
+++ b/services/AiJsonExtractor.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace app\services;
+
+use Yii;
+use yii\httpclient\Client;
+
+/**
+ * Generic helper for sending text to OpenAI and receiving structured JSON back.
+ */
+class AiJsonExtractor
+{
+    /**
+     * Calls OpenAI chat completion API with given system prompt and user text.
+     *
+     * @param string $text
+     * @param string $systemPrompt
+     * @return array
+     */
+    public function extract(string $text, string $systemPrompt): array
+    {
+        $apiKey = Yii::$app->params['openaiApiKey'] ?? null;
+        if (!$apiKey) {
+            return [];
+        }
+
+        $client = new Client(['baseUrl' => 'https://api.openai.com/v1']);
+        $response = $client->post('chat/completions', [
+            'model' => 'gpt-4o-mini',
+            'messages' => [
+                ['role' => 'system', 'content' => $systemPrompt],
+                ['role' => 'user', 'content' => $text],
+            ],
+        ])->addHeaders([
+            'Authorization' => 'Bearer ' . $apiKey,
+        ])->send();
+
+        if (!$response->isOk) {
+            Yii::error('OpenAI error: ' . $response->content, 'application');
+            return [];
+        }
+
+        $raw = $response->data['choices'][0]['message']['content'] ?? '{}';
+        $data = json_decode($raw, true);
+        return is_array($data) ? $data : [];
+    }
+}


### PR DESCRIPTION
## Summary
- add GPT controller with endpoints for audio-based task, result, and template extraction plus text task detection
- implement OpenAI audio transcription service
- implement generic JSON extractor for ChatGPT responses

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e5fb7895c83329b9d0e984adcf536