### PR TITLE
Add Telegram and GPT tokens to params config

### DIFF
--- a/config/params.php
+++ b/config/params.php
@@ -4,4 +4,6 @@ return [
     'adminEmail' => 'admin@example.com',
     'senderEmail' => 'noreply@example.com',
     'senderName' => 'Example.com mailer',
+    'telegramBotToken' => '7847589482:AAHEkcvHIsGuSGnJ0gv9Ysur5e6f5Bak7W0',
+    'gptToken' => '',
 ];


### PR DESCRIPTION
## Summary
- add Telegram bot token to params.php
- add placeholder for GPT token

## Testing
- `composer test` *(Command "test" is not defined)*
- `./vendor/bin/codecept run` *(No such file or directory)*
- `composer install` *(failed: CONNECT tunnel failed 403 requiring GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_689e633140f48332b995795addabc972