### PR TITLE
Notify external server when saving new task

### DIFF
--- a/config/params.php
+++ b/config/params.php
@@ -6,4 +6,5 @@ return [
     'senderName' => 'Example.com mailer',
     'telegramBotToken' => '7847589482:AAHEkcvHIsGuSGnJ0gv9Ysur5e6f5Bak7W0',
     'gptToken' => '',
+    'taskNotifyUrl' => '',
 ];


### PR DESCRIPTION
## Summary
- send POST request to configured server when a new task is saved
- add `taskNotifyUrl` application parameter for the webhook endpoint

## Testing
- `vendor/bin/codecept run` *(fails: vendor/bin/codecept: No such file or directory)*
- `composer install` *(fails: GitHub API 403 responses during dependency download)*

------
https://chatgpt.com/codex/tasks/task_e_689f755198ec8332a134daed94c4742a